### PR TITLE
Prevent doc parsing failure when the range attribute is not present on a property

### DIFF
--- a/src/hydra/parseHydraDocumentation.js
+++ b/src/hydra/parseHydraDocumentation.js
@@ -115,27 +115,28 @@ export default function parseHydraDocumentation(entrypointUrl, options = {}) {
         }
 
         const supportedClass = findSupportedClass(docs, className);
-        for (let supportedProperty of supportedClass['http://www.w3.org/ns/hydra/core#supportedProperty']) {
-          const range = supportedProperty['http://www.w3.org/ns/hydra/core#property'][0]['http://www.w3.org/2000/01/rdf-schema#range'][0]['@id'];
+        for (let supportedProperties of supportedClass['http://www.w3.org/ns/hydra/core#supportedProperty']) {
+          const supportedProperty = supportedProperties['http://www.w3.org/ns/hydra/core#property'][0];
+          const range = supportedProperty['http://www.w3.org/2000/01/rdf-schema#range'] ? supportedProperty['http://www.w3.org/2000/01/rdf-schema#range'][0]['@id'] : null;
 
           const field = new Field(
-            supportedProperty['http://www.w3.org/ns/hydra/core#property'][0]['http://www.w3.org/2000/01/rdf-schema#label'][0]['@value'],
+            supportedProperty['http://www.w3.org/2000/01/rdf-schema#label'][0]['@value'],
             {
-              id: supportedProperty['http://www.w3.org/ns/hydra/core#property'][0]['@id'],
+              id: supportedProperty['@id'],
               range,
-              reference: 'http://www.w3.org/ns/hydra/core#Link' === supportedProperty['http://www.w3.org/ns/hydra/core#property'][0]['@type'][0] ? range : null, // Will be updated in a subsequent pass
-              required: supportedProperty['http://www.w3.org/ns/hydra/core#required'] ? supportedProperty['http://www.w3.org/ns/hydra/core#required'][0]['@value'] : false,
-              description: supportedProperty['http://www.w3.org/ns/hydra/core#description'] ? supportedProperty['http://www.w3.org/ns/hydra/core#description'][0]['@value'] : ''
+              reference: 'http://www.w3.org/ns/hydra/core#Link' === property['@type'][0] ? range : null, // Will be updated in a subsequent pass
+              required: supportedProperties['http://www.w3.org/ns/hydra/core#required'] ? supportedProperties['http://www.w3.org/ns/hydra/core#required'][0]['@value'] : false,
+              description: supportedProperties['http://www.w3.org/ns/hydra/core#description'] ? supportedProperties['http://www.w3.org/ns/hydra/core#description'][0]['@value'] : ''
             },
           );
 
           fields.push(field);
 
-          if (supportedProperty['http://www.w3.org/ns/hydra/core#readable'][0]['@value']) {
+          if (supportedProperties['http://www.w3.org/ns/hydra/core#readable'][0]['@value']) {
             readableFields.push(field);
           }
 
-          if (supportedProperty['http://www.w3.org/ns/hydra/core#writable'][0]['@value']) {
+          if (supportedProperties['http://www.w3.org/ns/hydra/core#writable'][0]['@value']) {
             writableFields.push(field);
           }
         }
@@ -158,7 +159,7 @@ export default function parseHydraDocumentation(entrypointUrl, options = {}) {
     // Resolve references
     for (let field of fields) {
       if (null !== field.reference) {
-        field.reference = resources.find(resource => resource.id === field.reference);
+        field.reference = resources.find(resource => resource.id === field.reference) || null;
       }
     }
 

--- a/src/hydra/parseHydraDocumentation.test.js
+++ b/src/hydra/parseHydraDocumentation.test.js
@@ -2,23 +2,28 @@ import parseHydraDocumentation from './parseHydraDocumentation';
 
 test('parse a Hydra documentation', () => {
   const entrypoint = `{
-  "@context": {
-    "@vocab": "http://localhost/docs.jsonld#",
+    "@context": {
+      "@vocab": "http://localhost/docs.jsonld#",
       "hydra": "http://www.w3.org/ns/hydra/core#",
       "book": {
-      "@id": "Entrypoint/book",
+        "@id": "Entrypoint/book",
         "@type": "@id"
+      },
+      "review": {
+        "@id": "Entrypoint/review",
+        "@type": "@id"
+      },
+      "customResource": {
+        "@id": "Entrypoint/customResource",
+        "@type": "@id"
+      }
     },
-    "review": {
-      "@id": "Entrypoint/review",
-        "@type": "@id"
-    }
-  },
-  "@id": "/",
+    "@id": "/",
     "@type": "Entrypoint",
     "book": "/books",
-    "review": "/reviews"
-}`;
+    "review": "/reviews",
+    "customResource": "/customResources"
+  }`;
 
   const docs = `{
   "@context": {
@@ -238,6 +243,73 @@ test('parse a Hydra documentation', () => {
       ]
     },
     {
+      "@id": "#CustomResource",
+      "@type": "hydra:Class",
+      "rdfs:label": "CustomResource",
+      "hydra:title": "CustomResource",
+      "hydra:description": "A custom resource.",
+      "hydra:supportedProperty": [
+        {
+          "@type": "hydra:SupportedProperty",
+          "hydra:property": {
+            "@id": "#CustomResource/label",
+            "@type": "rdf:Property",
+            "rdfs:label": "label",
+            "domain": "#CustomResource",
+            "range": "xmls:string"
+          },
+          "hydra:title": "label",
+          "hydra:required": true,
+          "hydra:readable": true,
+          "hydra:writable": true
+        },
+        {
+          "@type": "hydra:SupportedProperty",
+          "hydra:property": {
+            "@id": "#CustomResource/description",
+            "@type": "rdf:Property",
+            "rdfs:label": "description",
+            "domain": "#CustomResource",
+            "range": "xmls:string"
+          },
+          "hydra:title": "description",
+          "hydra:required": true,
+          "hydra:readable": true,
+          "hydra:writable": true
+        },
+        {
+          "@type": "hydra:SupportedProperty",
+          "hydra:property": {
+            "@id": "#CustomResource/sanitizedDescription",
+            "@type": "rdf:Property",
+            "rdfs:label": "sanitizedDescription",
+            "domain": "#CustomResource"
+          },
+          "hydra:title": "sanitizedDescription",
+          "hydra:required": false,
+          "hydra:readable": true,
+          "hydra:writable": false
+        }
+      ],
+      "hydra:supportedOperation": [
+        {
+          "@type": "hydra:Operation",
+          "hydra:method": "GET",
+          "hydra:title": "Retrieves custom resources.",
+          "rdfs:label": "Retrieves custom resources.",
+          "returns": "#CustomResource"
+        },
+        {
+          "@type": "hydra:CreateResourceOperation",
+          "expects": "#CustomResource",
+          "hydra:method": "POST",
+          "hydra:title": "Creates a custom resource.",
+          "rdfs:label": "Creates a custom resource.",
+          "returns": "#CustomResource"
+        }
+      ]
+    },
+    {
       "@id": "#Entrypoint",
       "@type": "hydra:Class",
       "hydra:title": "The API entrypoint",
@@ -299,6 +371,36 @@ test('parse a Hydra documentation', () => {
             ]
           },
           "hydra:title": "The collection of Review resources",
+          "hydra:readable": true,
+          "hydra:writable": false
+        },
+        {
+          "@type": "hydra:SupportedProperty",
+          "hydra:property": {
+            "@id": "#Entrypoint/customResource",
+            "@type": "hydra:Link",
+            "domain": "#Entrypoint",
+            "rdfs:label": "The collection of custom resources",
+            "range": "hydra:PagedCollection",
+            "hydra:supportedOperation": [
+              {
+                "@type": "hydra:Operation",
+                "hydra:method": "GET",
+                "hydra:title": "Retrieves the collection of custom resources.",
+                "rdfs:label": "Retrieves the collection of custom resources.",
+                "returns": "hydra:PagedCollection"
+              },
+              {
+                "@type": "hydra:CreateResourceOperation",
+                "expects": "#CustomResource",
+                "hydra:method": "POST",
+                "hydra:title": "Creates a custom resource.",
+                "rdfs:label": "Creates a custom resource.",
+                "returns": "#CustomResource"
+              }
+            ]
+          },
+          "hydra:title": "The collection of custom resources",
           "hydra:readable": true,
           "hydra:writable": false
         }
@@ -706,6 +808,56 @@ test('parse a Hydra documentation', () => {
                 },
                 "required": true,
                 "description": "The item that is being reviewed/rated"
+              }
+            ]
+          },
+          {
+            name: "customResources",
+            url: "http://localhost/customResources",
+            id: "http://localhost/docs.jsonld#CustomResource",
+            title: "CustomResource",
+            readableFields: [
+              {
+                "name": "label",
+                "id": "http://localhost/docs.jsonld#CustomResource/label",
+                "range": "http://www.w3.org/2001/XMLSchema#string",
+                "reference": null,
+                "required": true,
+                "description": ""
+              },
+              {
+                "name": "description",
+                "id": "http://localhost/docs.jsonld#CustomResource/description",
+                "range": "http://www.w3.org/2001/XMLSchema#string",
+                "reference": null,
+                "required": true,
+                "description": ""
+              },
+              {
+                "name": "sanitizedDescription",
+                "id": "http://localhost/docs.jsonld#CustomResource/sanitizedDescription",
+                "range": null,
+                "reference": null,
+                "required": false,
+                "description": ""
+              }
+            ],
+            "writableFields": [
+              {
+                "name": "label",
+                "id": "http://localhost/docs.jsonld#CustomResource/label",
+                "range": "http://www.w3.org/2001/XMLSchema#string",
+                "reference": null,
+                "required": true,
+                "description": ""
+              },
+              {
+                "name": "description",
+                "id": "http://localhost/docs.jsonld#CustomResource/description",
+                "range": "http://www.w3.org/2001/XMLSchema#string",
+                "reference": null,
+                "required": true,
+                "description": ""
               }
             ]
           }


### PR DESCRIPTION
Hi there,

I once experienced the same issue as @vitalyiegorov in dunglas/api-doc-parser#6 (also api-platform/admin#8).
This is caused by an `undefined` `range` for a property:
```
        {
          "@type": "hydra:SupportedProperty",
          "hydra:property": {
            "@id": "#CustomResource/sanitizedDescription",
            "@type": "rdf:Property",
            "rdfs:label": "sanitizedDescription",
            "domain": "#CustomResource"
          },
          "hydra:title": "sanitizedDescription",
          "hydra:required": false,
          "hydra:readable": true,
          "hydra:writable": false
        }
```

Regarding [api-platform/core](https://github.com/api-platform/core), you can stumble on this when defining a custom `getter` which is not directly correlated with a class property name. This happens when attempting to map PHP types to Json-ld types. 

This is directly linked to the [symfony/property-info](https://github.com/symfony/property-info) which just omit those kind of getters.

I'm not aware if this is the intended behaviour. Can you think of any workaround for such behaviour?

Anyway, this should'nt prevent the doc from being parsed. Furthermore, this case is covered in `api-platform/admin` in the `FieldFactory` which will default to `text` if no range is found.

