### PR TITLE
Handle "fetch" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you plan to use the library with Node, you also need a polyfill for the `fetc
 ```javascript
 import parseHydraDocumentation from 'api-doc-parser/lib/hydra/parseHydraDocumentation';
 
-parseHydraDocumentation('https://demo.api-platform.com').then(api => console.log(api));
+parseHydraDocumentation('https://demo.api-platform.com').then(({api}) => console.log(api));
 ```
 
 ## Support for other formats (Swagger/OpenAPI, API Blueprint, JSONAPI...)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^3.18.0",
     "eslint-plugin-import": "^2.2.0",
     "flow-bin": "^0.42.0",
-    "jest": "^19.0.2",
+    "jest": "^20.0.0",
     "jest-fetch-mock": "^1.0.8"
   },
   "dependencies": {

--- a/src/Api.js
+++ b/src/Api.js
@@ -4,7 +4,7 @@ import Resource from './Resource';
 
 type ApiOptions = {
   title?: string,
-  resource?: Map<string, Resource>,
+  resources?: Map<string, Resource>,
 }
 
 /**

--- a/src/hydra/fetchJsonLd.js
+++ b/src/hydra/fetchJsonLd.js
@@ -22,10 +22,10 @@ export default function fetchJsonLd(url, options = {}) {
 
   return fetch(url, options)
     .then(response => {
-      if (!response.headers.has('Content-Type') || !response.headers.get('Content-Type').includes(jsonLdMimeType)) {
-        return {response: response};
+      if (false === response.ok || !response.headers.has('Content-Type') || !response.headers.get('Content-Type').includes(jsonLdMimeType)) {
+        return Promise.reject({ response });
       }
 
-      return response.json().then(body => ({ response, body, document: body }));
+      return Promise.resolve(response.json().then(body => ({ response, body, document: body })));
     });
 }

--- a/src/hydra/fetchJsonLd.test.js
+++ b/src/hydra/fetchJsonLd.test.js
@@ -19,7 +19,7 @@ test('fetch a JSON-LD document', () => {
 test('fetch a non JSON-LD document', () => {
   fetch.mockResponseOnce(`<body>Hello</body>`, {status: 200, statusText: 'OK', headers: new Headers({'Content-Type': 'text/html'})});
 
-  return fetchJsonLd('/foo.jsonld').then(data => {
+  return fetchJsonLd('/foo.jsonld').catch(data => {
       expect(data.response.ok).toBe(true);
       expect(typeof data.body).toBe('undefined');
     }
@@ -35,9 +35,10 @@ test('fetch an error', () => {
     "spouse": "http://dbpedia.org/resource/Cynthia_Lennon"
 }`, {status: 400, statusText: 'Bad Request', headers: new Headers({'Content-Type': 'application/ld+json'})});
 
-  return fetchJsonLd('/foo.jsonld').then(data => {
-      expect(data.response.ok).toBe(false);
-      expect(data.body.born).toBe('1940-10-09');
-    }
-  );
+  return fetchJsonLd('/foo.jsonld').catch(({response}) => {
+    response.json().then(body => {
+      expect(response.ok).toBe(false);
+      expect(body.born).toBe('1940-10-09');
+    });
+  });
 });

--- a/src/hydra/parseHydraDocumentation.test.js
+++ b/src/hydra/parseHydraDocumentation.test.js
@@ -1181,9 +1181,40 @@ test('parse a Hydra documentation', () => {
       };
 
       // TODO: find some something cleaner ;)
-      expect(JSON.stringify(data, null, 2)).toBe(JSON.stringify(expectedApi, null, 2));
+      expect(JSON.stringify(data.api, null, 2)).toBe(JSON.stringify(expectedApi, null, 2));
+      expect(data.response).toBeDefined();
+      expect(data.status).toBe(200);
+
       expect(fetch).toHaveBeenCalledTimes(2);
       expect(fetch).toHaveBeenLastCalledWith('http://localhost/docs.jsonld', options);
     }
   );
+});
+
+test('parse a Hydra documentation without authorization', () => {
+  const init = {
+    status: 401,
+    statusText: 'Unauthorized',
+  };
+
+  const expectedApi = {
+    entrypoint: 'http://localhost',
+    resources: [],
+  };
+
+  const expectedResponse = {
+    code: 401,
+    message: 'JWT Token not found'
+  };
+
+  fetch.mockResponses(
+    [JSON.stringify(expectedResponse), init],
+  );
+
+  return parseHydraDocumentation('http://localhost').catch(async data => {
+    expect(data.api).toEqual(expectedApi);
+    expect(data.response).toBeDefined();
+    await expect(data.response.json()).resolves.toEqual(expectedResponse);
+    expect(data.status).toBe(401);
+  });
 });


### PR DESCRIPTION
I added properties `response` and `status` to `Api`.

If [response.ok](https://developer.mozilla.org/fr/docs/Web/API/Response/ok) is:
* `false`, the `fetch` promise will be rejected.
* `true`, the original behaviors is kept.

In all cases:
* the `response` will be returned (see `src/hydra/fetchJsonLd.json`).
* an instance of `Api` instance will be created and the returned `response` will be injected (see `src/hydra/parseHydraDocumentation.json`).

---

With this PR, we can now handle fetch error (should fix issue #12).